### PR TITLE
Add new option to exclude routes from being tracked

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,12 @@ module.exports = {
 
 Domain you entered on plausible.io e.g. blog.example.com.
 
-#### excludeRoutes (optional)
+#### excludePages (optional)
 
-- Type: `String` or `Array[String]`
+- Type: `Array[String]`
 - Default: None
 
-Do not track visits to the listed routes. Can either be a comma-separated string of routes, or an array of strings, each representing a route to ignore.
+Do not track visits to the listed pages. Should be an array of strings, each representing a page to ignore.
 For more information, check [Excluding Pages on Plausible](https://plausible.io/docs/excluding-pages).
 
 #### outboundLinkTracking (optional)

--- a/README.md
+++ b/README.md
@@ -43,6 +43,14 @@ module.exports = {
 
 Domain you entered on plausible.io e.g. blog.example.com.
 
+#### excludeRoutes (optional)
+
+- Type: `String` or `Array[String]`
+- Default: None
+
+Do not track visits to the listed routes. Can either be a comma-separated string of routes, or an array of strings, each representing a route to ignore.
+For more information, check [Excluding Pages on Plausible](https://plausible.io/docs/excluding-pages).
+
 #### outboundLinkTracking (optional)
 
 - Type: `boolean`

--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -4,19 +4,42 @@ export default function (Vue, options, context) {
         return;
     }
 
+    if (options.excludeRoutes && typeof options.excludeRoutes !== 'string' && !Array.isArray(options.excludeRoutes)) {
+      console.error("If supplied, excludeRoutes has to be a String or Array of routes to exclude.");
+      return;
+    }
+
     var host = options.customDomain ? options.customDomain : "plausible.io";
-    var postfix = (options.outboundLinkTracking ? '.outbound-links' : '') + `.js`;
+    var postfix = '';
+    var excludeRoutes;
     var filename;
+
+    if (options.excludeRoutes && Array.isArray(options.excludeRoutes)) {
+      excludeRoutes = options.excludeRoutes.join(', ');
+    } else if (options.excludeRoutes) {
+      excludeRoutes = options.excludeRoutes;
+    }
+
+    if (excludeRoutes) postfix += '.exclusions';
+    if (options.outboundLinkTracking) postfix += '.outbound-links';
+    postfix += '.js';
+
     if (options.customDomain) {
         filename = 'index' + postfix;
     } else {
         filename = 'plausible' + postfix;
     }
 
-    context.head.script.push({
+    var script = {
         "src": "https://" + host + "/js/" + filename,
         "async": true,
         "defer": true,
         "data-domain": options.dataDomain
-    })
+    };
+
+    if (excludeRoutes) {
+      script["data-exclude"] = excludeRoutes;
+    }
+
+    context.head.script.push(script);
 }

--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -4,23 +4,21 @@ export default function (Vue, options, context) {
         return;
     }
 
-    if (options.excludeRoutes && typeof options.excludeRoutes !== 'string' && !Array.isArray(options.excludeRoutes)) {
-      console.error("If supplied, excludeRoutes has to be a String or Array of routes to exclude.");
+    if (options.excludePages && !Array.isArray(options.excludePages)) {
+      console.error("If supplied, excludePages has to be an array of pages to exclude.");
       return;
     }
 
     var host = options.customDomain ? options.customDomain : "plausible.io";
     var postfix = '';
-    var excludeRoutes;
+    var excludePages;
     var filename;
 
-    if (options.excludeRoutes && Array.isArray(options.excludeRoutes)) {
-      excludeRoutes = options.excludeRoutes.join(', ');
-    } else if (options.excludeRoutes) {
-      excludeRoutes = options.excludeRoutes;
+    if (options.excludePages && options.excludePages.length > 0) {
+      excludePages = options.excludePages.join(', ');
     }
 
-    if (excludeRoutes) postfix += '.exclusions';
+    if (excludePages) postfix += '.exclusions';
     if (options.outboundLinkTracking) postfix += '.outbound-links';
     postfix += '.js';
 
@@ -37,8 +35,8 @@ export default function (Vue, options, context) {
         "data-domain": options.dataDomain
     };
 
-    if (excludeRoutes) {
-      script["data-exclude"] = excludeRoutes;
+    if (excludePages) {
+      script["data-exclude"] = excludePages;
     }
 
     context.head.script.push(script);


### PR DESCRIPTION
Sometimes it might be beneficial to not track visits to certain routes. With these changes, a different version of the tracker script will be used that allows excluding routes based on a data-attribute. Unless the  `excludeRoutes` option is set in the config, the plugin works as before, using either the simple tracker or the outboundLinks tracker.

It’s also possible to use both `excludeRoutes` and `outboundLinkTracking` at the same time.

For more information on how this works, you can check [Excluding Pages](https://plausible.io/docs/excluding-pages) and [Script Extensions](https://plausible.io/docs/script-extensions) on the Plausible Docs.

This is my first time actually contributing code to an open-source project on GitHub, so I hope I did everything right. :sweat_smile: 