### PR TITLE
#2 Update filename of plausible script

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,4 +68,15 @@ Custom domain you set up on plausible.io to serve the js-snippet e.g. `stats.[yo
 
 ## Development notes
 
-- Testing plugin, see https://gridsome.org/docs/how-to-create-a-plugin/#testing-your-plugin
+
+- Testing Plugin
+  1. [Create a new Gridsome project](/docs/#2-create-a-gridsome-project) (if you don't want to test with an existing one)
+  2. Open a terminal in your plugin project directory
+  3. `npm link` or `yarn link`
+  4. Open a terminal in your Gridsome project
+  5. `npm link my-plugin-name` or `yarn link my-plugin-name`
+  6. `gridsome develop`
+  7. After testing:
+     * First in project: `npm unlink --no-save cowabunga`
+     * Second in plugin: `npm unlink`
+  - Source: https://gridsome.org/docs/how-to-create-a-plugin/#testing-your-plugin

--- a/gridsome.client.js
+++ b/gridsome.client.js
@@ -22,11 +22,7 @@ export default function (Vue, options, context) {
     if (options.outboundLinkTracking) postfix += '.outbound-links';
     postfix += '.js';
 
-    if (options.customDomain) {
-        filename = 'index' + postfix;
-    } else {
-        filename = 'plausible' + postfix;
-    }
+    filename = 'script' + postfix;
 
     var script = {
         "src": "https://" + host + "/js/" + filename,


### PR DESCRIPTION
Fixes #2 

Updates filename of plausible script to latest filename version of plausible.

The previously used filenames `index.js` and `plausible.js` currently still work, but to be sure I adjusted the filename to be save for the future.